### PR TITLE
Fix: repository reset now tracks actual git refs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ if (cliTasks.contains("rc")) {
 
 dependencies {
     implementation 'org.codehaus.groovy:groovy-all:2.4.15'
-    api 'org.kohsuke:github-api:1.95'
+    api 'org.kohsuke:github-api:1.131'
     implementation('org.spockframework:spock-core:1.2-groovy-2.4')
 
     testImplementation 'net.bytebuddy:byte-buddy:[1.9,2)'


### PR DESCRIPTION
Repository reset operation was comparing the captured refs with themselves. Fix now makes it compare the captured refs with current repository refs.
Also had to add a conditional explicitly excluding PRs from the ref iteration, as for some reason github puts PRs as refs 🤔 

Also added more in depth testing for the repository reset operation, and updated github-api lib to latest version.

## Changes
* ![FIX] repository reset now compare older refs with current refs
* ![UPDATE] `org.kohsuke:github-api` library to 1.131

[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"
