### PR TITLE
Add snyk monitoring [ATLAS-673]

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,11 +1,13 @@
 #!groovy
 @Library('github.com/wooga/atlas-jenkins-pipeline@1.x') _
 withCredentials([usernamePassword(credentialsId: 'github_integration', passwordVariable: 'githubPassword', usernameVariable: 'githubUser'),
-                 string(credentialsId: 'spock_github_extension_coveralls_token', variable: 'coveralls_token')]) {
+                 string(credentialsId: 'snyk-wdk-token', variable: 'SNYK_TOKEN')]) {
 
     def testEnvironment = [
             "ATLAS_GITHUB_INTEGRATION_USER=${githubUser}",
             "ATLAS_GITHUB_INTEGRATION_PASSWORD=${githubPassword}"
     ]
-    buildJavaLibraryOSSRH coverallsToken: coveralls_token, testEnvironment: testEnvironment
+    withEnv(['SNYK_ORG_NAME=wooga-pipeline', 'SNYK_AUTO_DOWNLOAD=YES']) {
+        buildJavaLibraryOSSRH testEnvironment: testEnvironment
+    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -22,8 +22,10 @@ plugins {
     id 'signing'
     id 'nebula.release' version '15.3.1'
     id 'jacoco'
-    id 'com.github.kt3k.coveralls' version '2.12.0'
     id "io.github.gradle-nexus.publish-plugin" version "1.1.0"
+    id 'net.wooga.snyk' version '0.10.0'
+    id "net.wooga.snyk-wdk-java" version "0.3.0"
+    id "net.wooga.cve-dependency-resolution" version "0.3.0"
 }
 
 group "com.wooga.spock.extensions"
@@ -35,9 +37,9 @@ if (cliTasks.contains("rc")) {
 }
 
 dependencies {
-    implementation 'org.codehaus.groovy:groovy-all:2.4.15'
+    implementation 'org.codehaus.groovy:groovy-all:2.5.14'
     api 'org.kohsuke:github-api:[1.95,2)'
-    implementation('org.spockframework:spock-core:1.2-groovy-2.4')
+    implementation('org.spockframework:spock-core:1.3-groovy-2.5')
 
     testImplementation 'net.bytebuddy:byte-buddy:[1.9,2)'
     testImplementation 'com.github.stefanbirkner:system-rules:[1.18,2)'

--- a/src/test/groovy/com/wooga/spock/extensions/github/GithubRepositoryBuilderSpec.groovy
+++ b/src/test/groovy/com/wooga/spock/extensions/github/GithubRepositoryBuilderSpec.groovy
@@ -73,7 +73,7 @@ class GithubRepositoryBuilderSpec extends Specification {
         repo.createIssue("Test Issue").create()
 
         then:
-        e = thrown(GHFileNotFoundException)
+        e = thrown(HttpException)
         e.message.contains("Issues are disabled for this repo")
 
         and: "has no wiki"

--- a/src/test/groovy/com/wooga/spock/extensions/github/api/RateLimitHandlerWaitSpec.groovy
+++ b/src/test/groovy/com/wooga/spock/extensions/github/api/RateLimitHandlerWaitSpec.groovy
@@ -55,8 +55,8 @@ class RateLimitHandlerWaitSpec extends Specification {
         rateLimitResetMilis << [5000, 15000]
         message = rateLimitResetMilis < 10000 ? "for minimum wait time of 10 sec" : "until rate limit resets"
 
-        minTimeout = (Math.max(10000, rateLimitResetMilis) - 1000).longValue()
-        maxTimeout = (Math.max(10000, rateLimitResetMilis) + 1000).longValue()
+        minTimeout = (Math.max(10000, rateLimitResetMilis) - 2000).longValue()
+        maxTimeout = (Math.max(10000, rateLimitResetMilis) + 2000).longValue()
         waitTimeRange = (minTimeout..maxTimeout)
     }
 


### PR DESCRIPTION
## Description

This patch adds snyk monitoring to the build pipeline. It will hook itself into the check and publish stages.

The patch also sets a dependency helper plugin `net.wooga.cve-dependency-resolution` which applies overrides for dependencies with know fixes for security issues.

Along with the introduction of snyk I also upgraded/removed some depdencies. Coveralls produces a huge load of errors even with the latest version so I decided to remove it since we want/are moving to sonarqube (It is unknown at this time if this dependency is actually better or not).

## Changes

* ![ADD] `snyk` monitoring
* ![ADD] `net.wooga.snyk-wdk-java` snyk convention plugin
* ![ADD] `net.wogoa.cve-dependency-resolution` plugin
* ![REMOVE] coveralls plugin
* ![UPDATE] `org.codehaus.groovy:groovy-all` to version `2.5.14`
* ![UPDATE] `org.spockframework:spock-core` to version `1.3-groovy-2.5`

[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"
[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"



